### PR TITLE
Improve compatibility of the encoded output with Mathematica.

### DIFF
--- a/mcm_encode.py
+++ b/mcm_encode.py
@@ -29,6 +29,8 @@ def huffman_encode(body):
     result = []
     for i in range(0, len(body), 1):
         result.append(huffman_table[ord(body[i])])
+    # encode a final EOT character
+    result.append(huffman_table[4])
     bits = ''.join(result)
     # add trailing zeros to match a multiple 13 bits
     nzeros = 13 - (len(bits) % 13)
@@ -57,13 +59,13 @@ def main():
 
     with open(args.input_file, 'r') as file:
         body = file.read()
-    
+
     bits = huffman_encode(body)
     code = base95_encode(bits)
 
     with open(args.output_file, 'w+') as result_file:
         result_file.write('(*!1N!*)mcm\n');
-        result_file.write('\n'.join(split_string(code, 70)))
+        result_file.write('\n'.join(split_string(code, 70) + ['']))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- Encode a final EOT (End-Of-Transmission, ASCII 0x04) character.
- Add a final newline at the end of the formatted code dump.

### Test file and Mathematica output:

test.txt:
```
ab
```

Mathematica's `Encode["test.txt", "encrypt_ML.txt"]`
```
(*!1N!*)mcm
N_T3!!

```

### Before fix:

`python ./mcm_encode.py test.txt encrypt.txt`
```
(*!1N!*)mcm
#T
```

### After fix:

`python ./mcm_encode.py test.txt encrypt.txt`
```
(*!1N!*)mcm
N_T3!!

```